### PR TITLE
Refactor global constants into dedicated tileset module

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -5,17 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CivJS - Civilization Game Client</title>
-    <!-- Load freeciv constants BEFORE React starts -->
-    <script>
-      // Freeciv constants - must be available before tileset scripts
-      window.MATCH_NONE = 0;
-      window.MATCH_SAME = 1;
-      window.MATCH_PAIR = 2;
-      window.MATCH_FULL = 3;
-      window.CELL_WHOLE = 0;
-      window.CELL_CORNER = 1;
-      console.log('Freeciv constants defined inline:', window.MATCH_PAIR);
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/client/src/components/Canvas2D/MapRenderer.ts
+++ b/apps/client/src/components/Canvas2D/MapRenderer.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { GameState, MapViewport, Tile, Unit, City } from '../../types';
 import { TilesetLoader } from './TilesetLoader';
+import { CELL_WHOLE, CELL_CORNER, MATCH_NONE, MATCH_SAME, MATCH_FULL } from '../../constants/tileset';
 
 declare global {
   interface Window {
@@ -245,13 +246,8 @@ export class MapRenderer {
     const ts_tiles = (window as any).ts_tiles || {};
     const cellgroup_map = (window as any).cellgroup_map || {};
 
-    // Constants from freeciv-web tilespec.js - use the global window constants
-    const CELL_WHOLE = (window as any).CELL_WHOLE;
-    const CELL_CORNER = (window as any).CELL_CORNER;
-    const MATCH_NONE = (window as any).MATCH_NONE;
-    const MATCH_SAME = (window as any).MATCH_SAME;
-    // const MATCH_PAIR = (window as any).MATCH_PAIR;
-    // const MATCH_FULL = (window as any).MATCH_FULL;
+    // Constants from freeciv-web tilespec.js - now imported from constants module
+    // Import is at the top of the file
     const num_cardinal_tileset_dirs = 4;
     const NUM_CORNER_DIRS = 4;
     const DIR4_TO_DIR8 = [0, 2, 4, 6]; // Convert from DIR4 to DIR8
@@ -458,7 +454,7 @@ export class MapRenderer {
               array_index = array_index * 2 + b3;
               break;
             }
-            case (window as any).MATCH_FULL: {
+            case MATCH_FULL: {
               // Full match implementation
               const n = [];
               for (let j = 0; j < 3; j++) {

--- a/apps/client/src/constants/tileset.ts
+++ b/apps/client/src/constants/tileset.ts
@@ -1,0 +1,30 @@
+/**
+ * Tileset constants for freeciv-web compatibility
+ * These constants define matching styles and cell types for terrain rendering
+ */
+
+export const TILESET_CONSTANTS = {
+  // Match styles for terrain blending
+  MATCH_NONE: 0,
+  MATCH_SAME: 1,
+  MATCH_PAIR: 2,
+  MATCH_FULL: 3,
+  
+  // Cell types for sprite rendering
+  CELL_WHOLE: 0,
+  CELL_CORNER: 1
+} as const;
+
+// Export individual constants for convenience
+export const { 
+  MATCH_NONE, 
+  MATCH_SAME, 
+  MATCH_PAIR, 
+  MATCH_FULL,
+  CELL_WHOLE,
+  CELL_CORNER 
+} = TILESET_CONSTANTS;
+
+// Type definitions
+export type MatchStyle = typeof MATCH_NONE | typeof MATCH_SAME | typeof MATCH_PAIR | typeof MATCH_FULL;
+export type CellType = typeof CELL_WHOLE | typeof CELL_CORNER;


### PR DESCRIPTION
## Summary
- Moves Freeciv-related global constants from inline script in `index.html` to a new dedicated constants module `tileset.ts`
- Imports these constants in `MapRenderer.ts` instead of accessing them from the global `window` object
- Cleans up legacy inline script and improves code modularity and maintainability

## Changes

### Constants
- Created `apps/client/src/constants/tileset.ts` to define and export Freeciv tileset constants:
  - MATCH_NONE, MATCH_SAME, MATCH_PAIR, MATCH_FULL
  - CELL_WHOLE, CELL_CORNER
- Added TypeScript types for match styles and cell types

### MapRenderer Component
- Removed usage of global `window` constants
- Imported constants from `tileset.ts` and used them directly
- Updated code comments to reflect the new import approach

### Client HTML
- Removed inline `<script>` block defining Freeciv constants in `index.html`

## Test plan
- Verified that the map rendering logic using these constants behaves identically after the refactor
- Ensured no runtime errors due to missing constants
- Confirmed that the client loads and runs without the inline script block

This refactor improves code clarity by centralizing constants and removing reliance on global variables.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f06d9389-16a6-4f53-ae43-e88544dedc16