### PR TITLE
Refactor Freeciv constants into dedicated module with global initialization

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -5,17 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CivJS - Civilization Game Client</title>
-    <!-- Load freeciv constants BEFORE React starts -->
-    <script>
-      // Freeciv constants - must be available before tileset scripts
-      window.MATCH_NONE = 0;
-      window.MATCH_SAME = 1;
-      window.MATCH_PAIR = 2;
-      window.MATCH_FULL = 3;
-      window.CELL_WHOLE = 0;
-      window.CELL_CORNER = 1;
-      console.log('Freeciv constants defined inline:', window.MATCH_PAIR);
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/client/src/components/Canvas2D/MapRenderer.ts
+++ b/apps/client/src/components/Canvas2D/MapRenderer.ts
@@ -1,6 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { GameState, MapViewport, Tile, Unit, City } from '../../types';
 import { TilesetLoader } from './TilesetLoader';
+import {
+  MATCH_NONE,
+  MATCH_SAME,
+  MATCH_PAIR,
+  MATCH_FULL,
+  CELL_WHOLE,
+  CELL_CORNER,
+  DIR4_TO_DIR8,
+  CARDINAL_TILESET_DIRS,
+} from '../../constants/freeciv';
 
 declare global {
   interface Window {
@@ -245,17 +255,10 @@ export class MapRenderer {
     const ts_tiles = (window as any).ts_tiles || {};
     const cellgroup_map = (window as any).cellgroup_map || {};
 
-    // Constants from freeciv-web tilespec.js - use the global window constants
-    const CELL_WHOLE = (window as any).CELL_WHOLE;
-    const CELL_CORNER = (window as any).CELL_CORNER;
-    const MATCH_NONE = (window as any).MATCH_NONE;
-    const MATCH_SAME = (window as any).MATCH_SAME;
-    const MATCH_PAIR = (window as any).MATCH_PAIR;
-    const MATCH_FULL = (window as any).MATCH_FULL;
+    // Constants imported from freeciv constants module
     const num_cardinal_tileset_dirs = 4;
     const NUM_CORNER_DIRS = 4;
-    const DIR4_TO_DIR8 = [0, 4, 2, 6]; // N, S, E, W - for CELL_CORNER sprite mapping
-    const cardinal_tileset_dirs = [0, 2, 4, 6]; // N, E, S, W - for MATCH_SAME and dithering
+    const cardinal_tileset_dirs = CARDINAL_TILESET_DIRS;
     const dither_offset_x = [48, 0, 48, 0]; // Dither offsets for N, E, S, W (half tile width for N/S)
     const dither_offset_y = [0, 24, 24, 0]; // Dither offsets for N, E, S, W (half tile height for E/S)
     const tileset_tile_height = this.tileHeight;
@@ -281,7 +284,9 @@ export class MapRenderer {
                   if (
                     !tterrain_near ||
                     !tterrain_near[cardinal_tileset_dirs[i]] ||
-                    !ts_tiles[tterrain_near[cardinal_tileset_dirs[i]]['graphic_str']]
+                    !ts_tiles[
+                      tterrain_near[cardinal_tileset_dirs[i]]['graphic_str']
+                    ]
                   )
                     continue;
                   const near_dlp =
@@ -362,9 +367,13 @@ export class MapRenderer {
         ];
 
         // Get this terrain's match_index[0] from tile_types_setup
-        const this_match_index = 
-          tile_types_setup['l' + l + '.' + pterrain['graphic_str']] ? 
-          tile_types_setup['l' + l + '.' + pterrain['graphic_str']]['match_index'][0] : -1;
+        const this_match_index = tile_types_setup[
+          'l' + l + '.' + pterrain['graphic_str']
+        ]
+          ? tile_types_setup['l' + l + '.' + pterrain['graphic_str']][
+              'match_index'
+            ][0]
+          : -1;
 
         const result_sprites: Array<{
           key: string;
@@ -429,14 +438,27 @@ export class MapRenderer {
           // This matches the original freeciv-web implementation exactly
           const m = [
             // Counter-clockwise neighbor
-            tile_types_setup['l' + l + '.' + tterrain_near[dir_ccw(dir)]['graphic_str']] ?
-              tile_types_setup['l' + l + '.' + tterrain_near[dir_ccw(dir)]['graphic_str']]['match_index'][0] : -1,
+            tile_types_setup[
+              'l' + l + '.' + tterrain_near[dir_ccw(dir)]['graphic_str']
+            ]
+              ? tile_types_setup[
+                  'l' + l + '.' + tterrain_near[dir_ccw(dir)]['graphic_str']
+                ]['match_index'][0]
+              : -1,
             // Direct neighbor
-            tile_types_setup['l' + l + '.' + tterrain_near[dir]['graphic_str']] ?
-              tile_types_setup['l' + l + '.' + tterrain_near[dir]['graphic_str']]['match_index'][0] : -1,
+            tile_types_setup['l' + l + '.' + tterrain_near[dir]['graphic_str']]
+              ? tile_types_setup[
+                  'l' + l + '.' + tterrain_near[dir]['graphic_str']
+                ]['match_index'][0]
+              : -1,
             // Clockwise neighbor
-            tile_types_setup['l' + l + '.' + tterrain_near[dir_cw(dir)]['graphic_str']] ?
-              tile_types_setup['l' + l + '.' + tterrain_near[dir_cw(dir)]['graphic_str']]['match_index'][0] : -1,
+            tile_types_setup[
+              'l' + l + '.' + tterrain_near[dir_cw(dir)]['graphic_str']
+            ]
+              ? tile_types_setup[
+                  'l' + l + '.' + tterrain_near[dir_cw(dir)]['graphic_str']
+                ]['match_index'][0]
+              : -1,
           ];
 
           // Calculate array_index based on match style

--- a/apps/client/src/constants/freeciv.ts
+++ b/apps/client/src/constants/freeciv.ts
@@ -2,6 +2,9 @@
  * Freeciv constants for sprite matching and cell types
  * These constants are used for tileset sprite rendering and matching logic
  * Ported from freeciv-web to TypeScript
+ *
+ * NOTE: These constants are also exposed globally on window for compatibility
+ * with legacy freeciv-web tileset scripts loaded from the server.
  */
 
 // Sprite matching types
@@ -41,3 +44,26 @@ export const DIR4_TO_DIR8 = [0, 4, 2, 6] as const;
 
 // Cardinal directions for MATCH_SAME and dithering - N, E, S, W
 export const CARDINAL_TILESET_DIRS = [0, 2, 4, 6] as const;
+
+// Expose constants globally for compatibility with freeciv-web tileset scripts
+// This ensures that dynamically loaded JavaScript files from the server can access these constants
+declare global {
+  interface Window {
+    MATCH_NONE: number;
+    MATCH_SAME: number;
+    MATCH_PAIR: number;
+    MATCH_FULL: number;
+    CELL_WHOLE: number;
+    CELL_CORNER: number;
+  }
+}
+
+// Set global window properties for backward compatibility
+if (typeof window !== 'undefined') {
+  window.MATCH_NONE = MATCH_NONE;
+  window.MATCH_SAME = MATCH_SAME;
+  window.MATCH_PAIR = MATCH_PAIR;
+  window.MATCH_FULL = MATCH_FULL;
+  window.CELL_WHOLE = CELL_WHOLE;
+  window.CELL_CORNER = CELL_CORNER;
+}

--- a/apps/client/src/constants/freeciv.ts
+++ b/apps/client/src/constants/freeciv.ts
@@ -1,0 +1,43 @@
+/**
+ * Freeciv constants for sprite matching and cell types
+ * These constants are used for tileset sprite rendering and matching logic
+ * Ported from freeciv-web to TypeScript
+ */
+
+// Sprite matching types
+export const MATCH_NONE = 0;
+export const MATCH_SAME = 1;
+export const MATCH_PAIR = 2;
+export const MATCH_FULL = 3;
+
+// Cell rendering types
+export const CELL_WHOLE = 0;
+export const CELL_CORNER = 1;
+
+// Type definitions for better TypeScript support
+export type MatchType =
+  | typeof MATCH_NONE
+  | typeof MATCH_SAME
+  | typeof MATCH_PAIR
+  | typeof MATCH_FULL;
+export type CellType = typeof CELL_WHOLE | typeof CELL_CORNER;
+
+// Export all constants as a single object for easier importing
+export const FreecivConstants = {
+  MATCH_NONE,
+  MATCH_SAME,
+  MATCH_PAIR,
+  MATCH_FULL,
+  CELL_WHOLE,
+  CELL_CORNER,
+} as const;
+
+// Additional rendering constants that are commonly used with these constants
+export const NUM_CARDINAL_DIRS = 4;
+export const NUM_CORNER_DIRS = 4;
+
+// Direction mappings - N, S, E, W for CELL_CORNER sprite mapping
+export const DIR4_TO_DIR8 = [0, 4, 2, 6] as const;
+
+// Cardinal directions for MATCH_SAME and dithering - N, E, S, W
+export const CARDINAL_TILESET_DIRS = [0, 2, 4, 6] as const;

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -3,6 +3,10 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
 
+// Initialize freeciv constants globally before app starts
+// This ensures compatibility with server-side tileset scripts
+import './constants/freeciv';
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/package-lock.json
+++ b/package-lock.json
@@ -15340,7 +15340,7 @@
       "requires": {
         "@eslint/js": "^9.33.0",
         "@tailwindcss/vite": "^4.1.12",
-        "@types/jest": "*",
+        "@types/jest": "^30.0.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@types/react-router-dom": "^5.3.3",


### PR DESCRIPTION
## Summary
- Extracts Freeciv-related constants from inline script and global window usage into a dedicated TypeScript module
- Improves code organization and type safety by centralizing constants in `apps/client/src/constants/freeciv.ts`
- Updates `MapRenderer.ts` to import and use these constants directly instead of relying on global window variables
- Removes inline script defining Freeciv constants from `index.html`
- Adds global initialization of Freeciv constants in `main.tsx` to ensure compatibility with server-side tileset scripts

## Changes

### Constants Module
- Created `freeciv.ts` to export Freeciv constants such as `MATCH_NONE`, `MATCH_SAME`, `CELL_WHOLE`, and direction mappings
- Added TypeScript types for match and cell types
- Exposes constants globally on `window` for backward compatibility with legacy freeciv-web tileset scripts

### MapRenderer Component
- Replaced all references to global window constants with imports from the new constants module
- Cleaned up redundant variable declarations and improved readability

### Client HTML
- Removed inline script that defined Freeciv constants on the global window object before React initialization

### Main Entry
- Imported `freeciv.ts` in `main.tsx` to initialize global constants before app start

### Package Lock
- Minor update to `@types/jest` version in `package-lock.json`

## Test plan
- Verified that the map rendering and sprite matching logic continues to function correctly with the constants imported from the module
- Ensured no regressions in tile rendering behavior
- Confirmed no runtime errors related to missing constants

This refactor enhances maintainability and prepares the codebase for future improvements by modularizing key constants and ensuring global compatibility.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8757213e-b11c-495f-ba2b-f95feb38ecd6