### PR TITLE
Fix panning snap issue on small screens by enforcing minimum padding

### DIFF
--- a/apps/client/src/components/Canvas2D/MapRenderer.ts
+++ b/apps/client/src/components/Canvas2D/MapRenderer.ts
@@ -1281,7 +1281,8 @@ export class MapRenderer {
 
       // Very generous bounds - allow seeing entire map plus lots of padding
       // This matches freeciv-web's behavior which is quite permissive
-      const padding = Math.max(viewportWidth, viewportHeight); // Full viewport as padding
+      // Use consistent minimum padding to prevent snap-back on small screens
+      const padding = Math.max(viewportWidth, viewportHeight, 1200); // Minimum 1200px padding
 
       const minX = -(mapWidthGui + padding);
       const maxX = padding;


### PR DESCRIPTION
## Summary
- Fixes panning snap-back behavior on small screens in the map renderer
- Enforces a consistent minimum padding of 1200px to prevent unexpected snapping

## Changes

### MapRenderer Component
- Updated padding calculation to use `Math.max(viewportWidth, viewportHeight, 1200)` instead of just viewport dimensions
- This ensures a minimum padding of 1200px around the map, matching the behavior on larger screens

## Test plan
- [x] Verify that panning on small screen sizes no longer snaps back unexpectedly
- [x] Confirm that map rendering and panning behavior remains consistent on larger screens
- [x] Test various viewport sizes to ensure padding is applied correctly and snapping is smooth

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/81822f51-0500-4969-a8e6-f5a614e7d1a4