### PR TITLE
fix: update CORS policy to include civjs Vercel domains

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -32,11 +32,12 @@ const corsOrigins = (
     'http://localhost:3000',
     'http://localhost:3001',
     'https://civjs-client.vercel.app',
+    'https://civjs.vercel.app',
     config.server.corsOrigin,
   ];
 
-  // Allow all Vercel preview deployments for civjs-client
-  const isVercelPreview = origin.match(/^https:\/\/civjs-client-.*\.vercel\.app$/);
+  // Allow all Vercel preview deployments for civjs-client or civjs
+  const isVercelPreview = origin.match(/^https:\/\/civjs(-client)?-.*\.vercel\.app$/);
 
   if (allowedOrigins.indexOf(origin) !== -1 || isVercelPreview) {
     callback(null, true);

--- a/apps/server/src/serverless.ts
+++ b/apps/server/src/serverless.ts
@@ -31,11 +31,12 @@ const corsOrigins = (
     'http://localhost:3000',
     'http://localhost:3001',
     'https://civjs-client.vercel.app',
+    'https://civjs.vercel.app',
     config.server.corsOrigin,
   ];
 
-  // Allow all Vercel preview deployments for civjs-client
-  const isVercelPreview = origin.match(/^https:\/\/civjs-client-.*\.vercel\.app$/);
+  // Allow all Vercel preview deployments for civjs-client or civjs
+  const isVercelPreview = origin.match(/^https:\/\/civjs(-client)?-.*\.vercel\.app$/);
 
   if (allowedOrigins.indexOf(origin) !== -1 || isVercelPreview) {
     callback(null, true);


### PR DESCRIPTION
## Summary
- Updated CORS policy to allow requests from the main civjs Vercel domain in addition to civjs-client
- Extended Vercel preview deployment regex to support both civjs-client and civjs subdomains

## Changes

### Server and Serverless CORS Configuration
- Added `https://civjs.vercel.app` to the list of allowed CORS origins
- Modified regex to allow preview deployments for both `civjs-client` and `civjs` Vercel apps

## Test plan
- Verified that requests from `https://civjs.vercel.app` are accepted by the CORS middleware
- Confirmed that preview deployments matching `https://civjs-*.vercel.app` and `https://civjs-client-*.vercel.app` are allowed
- Ensured no disruption to existing allowed origins and preview deployments

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c41eb515-576a-481e-9887-3c55370207d0