### PR TITLE
Fix public assets loading by uncommenting public directory in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,7 @@ dist
 
 # Gatsby files
 .cache/
-public
+# public - commented out to allow apps/client/public assets
 
 # Vuepress build output
 .vuepress/dist


### PR DESCRIPTION
## Summary
- Uncommented the `public` directory in `.gitignore` to allow apps/client public assets to be included
- This change fixes issues with production background images not loading due to ignored public assets

## Changes

### Configuration
- Modified `.gitignore`:
  - Commented out the `public` directory ignore rule to ensure public assets are tracked and deployed

## Test plan
- [ ] Verify that public assets are correctly included in production builds
- [ ] Confirm that background images load properly in the production environment
- [ ] Check that no unintended files are included due to this change

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a9fe8147-1bbb-4038-b1c9-d135e4660a56