### PR TITLE
refactor: put game type and map size on same row, remove map preview

### DIFF
--- a/apps/client/src/components/GameCreationDialog.tsx
+++ b/apps/client/src/components/GameCreationDialog.tsx
@@ -113,7 +113,7 @@ export const GameCreationDialog: React.FC = () => {
                 />
               </div>
 
-              <div className="md:col-span-2">
+              <div>
                 <label htmlFor="gameType" className="block text-sm font-medium text-amber-700 mb-2">
                   Game Type
                 </label>
@@ -134,33 +134,6 @@ export const GameCreationDialog: React.FC = () => {
                     : 'Play with other human players online'}
                 </p>
               </div>
-            </div>
-
-            <div
-              className={`grid ${gameType === 'single' ? 'grid-cols-1 md:grid-cols-2' : 'grid-cols-2'} gap-4`}
-            >
-              {gameType === 'multiplayer' && (
-                <div>
-                  <label
-                    htmlFor="maxPlayers"
-                    className="block text-sm font-medium text-amber-700 mb-2"
-                  >
-                    Max Players
-                  </label>
-                  <select
-                    id="maxPlayers"
-                    value={maxPlayers}
-                    onChange={e => setMaxPlayers(Number(e.target.value))}
-                    className="w-full px-3 py-3 bg-amber-50 border border-amber-300 rounded-md text-amber-900 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 shadow-sm"
-                  >
-                    <option value={2}>2 Players</option>
-                    <option value={3}>3 Players</option>
-                    <option value={4}>4 Players</option>
-                    <option value={6}>6 Players</option>
-                    <option value={8}>8 Players</option>
-                  </select>
-                </div>
-              )}
 
               <div>
                 <label htmlFor="mapSize" className="block text-sm font-medium text-amber-700 mb-2">
@@ -181,18 +154,28 @@ export const GameCreationDialog: React.FC = () => {
               </div>
             </div>
 
-            <div className="bg-amber-200 border border-amber-300 p-4 rounded-md">
-              <h4 className="text-sm font-medium text-amber-700 mb-2">Map Preview</h4>
-              {mapSizeOptions.map(
-                option =>
-                  mapSize === option.value && (
-                    <div key={option.value} className="text-sm text-amber-600">
-                      <p className="font-medium">{option.label}</p>
-                      <p>{option.description}</p>
-                    </div>
-                  )
-              )}
-            </div>
+            {gameType === 'multiplayer' && (
+              <div>
+                <label
+                  htmlFor="maxPlayers"
+                  className="block text-sm font-medium text-amber-700 mb-2"
+                >
+                  Max Players
+                </label>
+                <select
+                  id="maxPlayers"
+                  value={maxPlayers}
+                  onChange={e => setMaxPlayers(Number(e.target.value))}
+                  className="w-full px-3 py-3 bg-amber-50 border border-amber-300 rounded-md text-amber-900 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500 shadow-sm md:max-w-xs"
+                >
+                  <option value={2}>2 Players</option>
+                  <option value={3}>3 Players</option>
+                  <option value={4}>4 Players</option>
+                  <option value={6}>6 Players</option>
+                  <option value={8}>8 Players</option>
+                </select>
+              </div>
+            )}
 
             {error && (
               <div className="p-3 bg-red-50 border border-red-300 rounded-md text-red-800 text-sm">


### PR DESCRIPTION
- Move Game Type and Map Size dropdowns to same row layout
- Remove Map Preview section to simplify interface
- Maintain Max Players dropdown for multiplayer mode

🤖 Generated with [Claude Code](https://claude.ai/code)