### PR TITLE
Add mouse hover tile info overlay on map canvas

### DIFF
--- a/apps/client/src/components/Canvas2D/TileHoverOverlay.tsx
+++ b/apps/client/src/components/Canvas2D/TileHoverOverlay.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface TileHoverOverlayProps {
+  tileInfo: string | null;
+}
+
+export const TileHoverOverlay: React.FC<TileHoverOverlayProps> = ({ tileInfo }) => {
+  if (!tileInfo) return null;
+
+  return (
+    <div className="absolute top-4 right-4 bg-black bg-opacity-75 text-white px-3 py-2 rounded-md text-sm font-mono pointer-events-none z-10">
+      {tileInfo}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- Adds a mouse hover feature to display tile information on the map canvas
- Shows terrain type and coordinates of the tile under the mouse pointer
- Introduces a new `TileHoverOverlay` component for displaying tile info

## Changes

### MapCanvas Component
- Added state `hoveredTile` to track currently hovered tile info
- Enhanced `handleMouseMove` to detect tile under mouse when not dragging
- Converts terrain names to human-readable format with coordinates
- Displays `TileHoverOverlay` component with the hovered tile info

### TileHoverOverlay Component
- New component that renders a styled overlay box with tile info text
- Only visible when there is tile info to show

## Test plan
- [x] Hover over different tiles and verify correct terrain and coordinates display
- [x] Confirm overlay disappears when not hovering over any tile
- [x] Ensure no interference with map dragging functionality
- [x] Verify UI styling and positioning of the overlay on the map canvas

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7a9961ee-f32b-4686-990e-f7608e5a970e