### PR TITLE
Refactor game session storage, restrict new players in non-waiting games, add refresh confirmation, update player connection tracking, and improve game list player counts

### DIFF
--- a/apps/client/src/components/GameRoute.tsx
+++ b/apps/client/src/components/GameRoute.tsx
@@ -4,7 +4,7 @@ import { useGameStore } from '../store/gameStore';
 import { gameClient } from '../services/GameClient';
 import { ConnectionDialog } from './ConnectionDialog';
 import { GameLayout } from './GameUI/GameLayout';
-import { getStoredPlayerName, isCurrentGameSinglePlayer, storePlayerNameForGame } from '../utils/gameSession';
+import { getStoredUsername, storeUsername } from '../utils/gameSession';
 
 export const GameRoute: React.FC = () => {
   const { gameId } = useParams<{ gameId: string }>();

--- a/apps/client/src/components/GameRoute.tsx
+++ b/apps/client/src/components/GameRoute.tsx
@@ -64,6 +64,18 @@ export const GameRoute: React.FC = () => {
       return;
     }
 
+    // Check if this is a page reload by looking at session storage
+    const isPageReload = sessionStorage.getItem('gameRouteLoaded');
+    if (isPageReload && gameId) {
+      // This is a page reload, redirect to lobby
+      sessionStorage.removeItem('gameRouteLoaded');
+      navigate('/browse-games');
+      return;
+    }
+
+    // Mark that GameRoute has been loaded
+    sessionStorage.setItem('gameRouteLoaded', 'true');
+
     if (gameClient.isConnected() && gameClient.getCurrentGameId() === gameId) {
       setClientState('running');
     } else {
@@ -79,9 +91,6 @@ export const GameRoute: React.FC = () => {
         'Are you sure you want to leave the game? You will be redirected to the game lobby.';
       event.preventDefault();
       event.returnValue = message;
-
-      // Note: We can't reliably redirect in beforeunload, so the user will need to
-      // manually navigate back to the lobby after refresh. This is actually better UX.
       return message;
     };
 
@@ -90,6 +99,8 @@ export const GameRoute: React.FC = () => {
     // Cleanup event listeners on component unmount
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
+      // Clear the flag when navigating away normally (not refresh)
+      sessionStorage.removeItem('gameRouteLoaded');
     };
   }, [gameId, navigate]);
 

--- a/apps/client/src/services/GameClient.ts
+++ b/apps/client/src/services/GameClient.ts
@@ -250,7 +250,6 @@ class GameClient {
   }
 
   private handleMapInfo(data: any) {
-
     // Store in global map variable exactly like freeciv-web: map = packet;
     (window as any).map = data;
 
@@ -269,7 +268,6 @@ class GameClient {
   }
 
   private handleTileInfo(data: any) {
-
     if ((window as any).tiles && data.tile !== undefined) {
       const tiles = (window as any).tiles;
       tiles[data.tile] = Object.assign(tiles[data.tile] || {}, data);
@@ -312,7 +310,6 @@ class GameClient {
   }
 
   private handleTileInfoBatch(data: any) {
-
     if (!(window as any).tiles || !data.tiles) return;
 
     const tiles = (window as any).tiles;

--- a/apps/client/src/utils/__tests__/gameSession.test.ts
+++ b/apps/client/src/utils/__tests__/gameSession.test.ts
@@ -2,13 +2,7 @@
  * Tests for gameSession utility functions
  */
 
-import {
-  storeGameSession,
-  getStoredGameSession,
-  clearGameSession,
-  isCurrentGameSinglePlayer,
-  getStoredPlayerName,
-} from '../gameSession';
+import { storeUsername, getStoredUsername, clearUsername } from '../gameSession';
 
 // Mock localStorage
 const mockLocalStorage = (() => {
@@ -35,121 +29,31 @@ describe('gameSession utilities', () => {
     mockLocalStorage.clear();
   });
 
-  describe('storeGameSession and getStoredGameSession', () => {
-    it('should store and retrieve game session data', () => {
-      const session = {
-        playerName: 'TestPlayer',
-        gameId: 'game123',
-        gameType: 'single' as const,
-      };
+  describe('storeUsername and getStoredUsername', () => {
+    it('should store and retrieve username', () => {
+      const username = 'TestPlayer';
 
-      storeGameSession(session);
-      const retrieved = getStoredGameSession();
+      storeUsername(username);
+      const retrieved = getStoredUsername();
 
-      expect(retrieved).toEqual(session);
+      expect(retrieved).toBe(username);
     });
 
-    it('should return null when no session is stored', () => {
-      const retrieved = getStoredGameSession();
+    it('should return null when no username is stored', () => {
+      const retrieved = getStoredUsername();
       expect(retrieved).toBeNull();
     });
-
-    it('should return null when gameId does not match stored gameId', () => {
-      const session = {
-        playerName: 'TestPlayer',
-        gameId: 'game123',
-        gameType: 'single' as const,
-      };
-
-      storeGameSession(session);
-      const retrieved = getStoredGameSession('different-game');
-
-      expect(retrieved).toBeNull();
-    });
-
-    it('should return session when gameId matches stored gameId', () => {
-      const session = {
-        playerName: 'TestPlayer',
-        gameId: 'game123',
-        gameType: 'single' as const,
-      };
-
-      storeGameSession(session);
-      const retrieved = getStoredGameSession('game123');
-
-      expect(retrieved).toEqual(session);
-    });
   });
 
-  describe('clearGameSession', () => {
-    it('should clear stored session data', () => {
-      const session = {
-        playerName: 'TestPlayer',
-        gameId: 'game123',
-        gameType: 'single' as const,
-      };
+  describe('clearUsername', () => {
+    it('should clear stored username', () => {
+      const username = 'TestPlayer';
 
-      storeGameSession(session);
-      expect(getStoredGameSession()).toEqual(session);
+      storeUsername(username);
+      expect(getStoredUsername()).toBe(username);
 
-      clearGameSession();
-      expect(getStoredGameSession()).toBeNull();
-    });
-  });
-
-  describe('isCurrentGameSinglePlayer', () => {
-    it('should return true for single player games', () => {
-      const session = {
-        playerName: 'TestPlayer',
-        gameId: 'game123',
-        gameType: 'single' as const,
-      };
-
-      storeGameSession(session);
-      expect(isCurrentGameSinglePlayer('game123')).toBe(true);
-    });
-
-    it('should return false for multiplayer games', () => {
-      const session = {
-        playerName: 'TestPlayer',
-        gameId: 'game123',
-        gameType: 'multiplayer' as const,
-      };
-
-      storeGameSession(session);
-      expect(isCurrentGameSinglePlayer('game123')).toBe(false);
-    });
-
-    it('should return false when no session exists', () => {
-      expect(isCurrentGameSinglePlayer('game123')).toBe(false);
-    });
-  });
-
-  describe('getStoredPlayerName', () => {
-    it('should return player name for matching game', () => {
-      const session = {
-        playerName: 'TestPlayer',
-        gameId: 'game123',
-        gameType: 'single' as const,
-      };
-
-      storeGameSession(session);
-      expect(getStoredPlayerName('game123')).toBe('TestPlayer');
-    });
-
-    it('should return null for non-matching game', () => {
-      const session = {
-        playerName: 'TestPlayer',
-        gameId: 'game123',
-        gameType: 'single' as const,
-      };
-
-      storeGameSession(session);
-      expect(getStoredPlayerName('different-game')).toBeNull();
-    });
-
-    it('should return null when no session exists', () => {
-      expect(getStoredPlayerName('game123')).toBeNull();
+      clearUsername();
+      expect(getStoredUsername()).toBeNull();
     });
   });
 });

--- a/apps/client/src/utils/gameSession.ts
+++ b/apps/client/src/utils/gameSession.ts
@@ -1,133 +1,42 @@
 /**
- * Utility for managing game session data in localStorage
- * Handles player identity persistence across browser refreshes
+ * Simple username storage utility, following freeciv-web's simpleStorage pattern
+ * Only stores username for login convenience, like the original implementation
  */
 
 const STORAGE_KEYS = {
-  PLAYER_NAME: 'civjs_player_name',
-  GAME_ID: 'civjs_current_game_id',
-  GAME_TYPE: 'civjs_game_type',
-  GAME_SESSIONS: 'civjs_game_sessions', // New key for per-game storage
+  USERNAME: 'civjs_username',
 } as const;
 
-export interface GameSession {
-  playerName: string;
-  gameId: string;
-  gameType: 'single' | 'multiplayer';
-}
-
 /**
- * Store game session data when creating or joining a game
+ * Store username for login convenience (like freeciv-web's simpleStorage)
  */
-export function storeGameSession(session: GameSession): void {
+export function storeUsername(username: string): void {
   try {
-    localStorage.setItem(STORAGE_KEYS.PLAYER_NAME, session.playerName);
-    localStorage.setItem(STORAGE_KEYS.GAME_ID, session.gameId);
-    localStorage.setItem(STORAGE_KEYS.GAME_TYPE, session.gameType);
+    localStorage.setItem(STORAGE_KEYS.USERNAME, username);
   } catch (error) {
-    console.warn('Failed to store game session:', error);
+    console.warn('Failed to store username:', error);
   }
 }
 
 /**
- * Retrieve stored game session data
+ * Retrieve stored username for login convenience
  */
-export function getStoredGameSession(gameId?: string): GameSession | null {
+export function getStoredUsername(): string | null {
   try {
-    const storedPlayerName = localStorage.getItem(STORAGE_KEYS.PLAYER_NAME);
-    const storedGameId = localStorage.getItem(STORAGE_KEYS.GAME_ID);
-    const storedGameType = localStorage.getItem(STORAGE_KEYS.GAME_TYPE);
-
-    // If a specific gameId is provided, ensure it matches stored data
-    if (gameId && storedGameId !== gameId) {
-      return null;
-    }
-
-    if (storedPlayerName && storedGameId && storedGameType) {
-      return {
-        playerName: storedPlayerName,
-        gameId: storedGameId,
-        gameType: storedGameType as 'single' | 'multiplayer',
-      };
-    }
+    return localStorage.getItem(STORAGE_KEYS.USERNAME);
   } catch (error) {
-    console.warn('Failed to retrieve game session:', error);
-  }
-
-  return null;
-}
-
-/**
- * Clear stored game session data
- */
-export function clearGameSession(): void {
-  try {
-    localStorage.removeItem(STORAGE_KEYS.PLAYER_NAME);
-    localStorage.removeItem(STORAGE_KEYS.GAME_ID);
-    localStorage.removeItem(STORAGE_KEYS.GAME_TYPE);
-  } catch (error) {
-    console.warn('Failed to clear game session:', error);
-  }
-}
-
-/**
- * Check if the current game session is for a single player game
- */
-export function isCurrentGameSinglePlayer(gameId: string): boolean {
-  try {
-    const sessions = getGameSessions();
-    return sessions[gameId]?.gameType === 'single' || false;
-  } catch (error) {
-    console.warn('Failed to check game type:', error);
-    // Fallback to legacy method
-    const session = getStoredGameSession(gameId);
-    return session?.gameType === 'single' || false;
-  }
-}
-
-/**
- * Store player name for a specific game
- */
-export function storePlayerNameForGame(gameId: string, playerName: string, gameType: 'single' | 'multiplayer'): void {
-  try {
-    const sessions = getGameSessions();
-    sessions[gameId] = { playerName, gameType };
-    localStorage.setItem(STORAGE_KEYS.GAME_SESSIONS, JSON.stringify(sessions));
-  } catch (error) {
-    console.warn('Failed to store player name for game:', error);
-  }
-}
-
-/**
- * Get stored player name for a specific game
- */
-export function getStoredPlayerName(gameId: string): string | null {
-  try {
-    const sessions = getGameSessions();
-    return sessions[gameId]?.playerName || null;
-  } catch (error) {
-    console.warn('Failed to get stored player name:', error);
+    console.warn('Failed to retrieve username:', error);
     return null;
   }
 }
 
 /**
- * Get all game sessions from localStorage
+ * Clear stored username
  */
-function getGameSessions(): Record<string, { playerName: string; gameType: 'single' | 'multiplayer' }> {
+export function clearUsername(): void {
   try {
-    const stored = localStorage.getItem(STORAGE_KEYS.GAME_SESSIONS);
-    return stored ? JSON.parse(stored) : {};
+    localStorage.removeItem(STORAGE_KEYS.USERNAME);
   } catch (error) {
-    console.warn('Failed to parse game sessions:', error);
-    return {};
+    console.warn('Failed to clear username:', error);
   }
-}
-
-/**
- * Get the stored player name for a specific game (legacy compatibility)
- */
-export function getStoredPlayerNameLegacy(gameId: string): string | null {
-  const session = getStoredGameSession(gameId);
-  return session?.playerName || null;
 }

--- a/apps/server/src/game/GameManager.ts
+++ b/apps/server/src/game/GameManager.ts
@@ -145,33 +145,13 @@ export class GameManager {
     }
 
     // Check if user is already in the game first
-    
     const existingPlayer = game.players.find(p => p.userId === userId);
     if (existingPlayer) {
       return existingPlayer.id; // Already joined - allow rejoining at any game status
     }
 
-    
-    // Special case: If this looks like a refresh scenario (single player game with one player),
-    // and the username suggests this user should be in the game, allow them to take over the existing player
+    // Only allow new players in waiting games
     if (game.status !== 'waiting') {
-      if (game.players.length === 1 && game.status === 'active') {
-        const existingPlayer = game.players[0];
-        // Check if the username pattern suggests this user should replace the existing single player
-        // This handles cases where page refresh creates a new userId but same username pattern
-        
-        // For now, just allow the rejoin attempt to help with testing
-        // TODO: Add more sophisticated logic to verify this is the same user
-        logger.info(`Allowing potential refresh scenario: replacing player ${existingPlayer.id} with new userId ${userId}`);
-        
-        // Update the existing player's userId to match the new connection
-        await db.update(players).set({ userId }).where(eq(players.id, existingPlayer.id));
-        
-        
-        return existingPlayer.id;
-      }
-      
-      logger.debug(`Game status is '${game.status}', not accepting new players`);
       throw new Error('Game is not accepting new players');
     }
 

--- a/apps/server/src/network/socket-handlers.ts
+++ b/apps/server/src/network/socket-handlers.ts
@@ -369,6 +369,7 @@ function registerHandlers(handler: PacketHandler, io: Server, socket: Socket) {
       const gameId = await gameManager.createGame({
         name: data.name,
         hostId: connection.userId,
+        gameType: data.gameType,
         maxPlayers: data.maxPlayers,
         mapWidth: data.mapWidth,
         mapHeight: data.mapHeight,

--- a/apps/server/src/network/socket-handlers.ts
+++ b/apps/server/src/network/socket-handlers.ts
@@ -113,7 +113,9 @@ export function setupSocketHandlers(io: Server, socket: Socket) {
 
   socket.on('get_game_list', async callback => {
     try {
-      const games = await gameManager.getGameListForLobby();
+      const connection = activeConnections.get(socket.id);
+      const userId = connection?.userId || null;
+      const games = await gameManager.getGameListForLobby(userId);
       callback({ success: true, games });
     } catch (error) {
       logger.error('Error getting game list:', error);
@@ -333,7 +335,9 @@ function registerHandlers(handler: PacketHandler, io: Server, socket: Socket) {
 
   handler.register(PacketType.GAME_LIST, async socket => {
     try {
-      const games = await gameManager.getGameListForLobby();
+      const connection = activeConnections.get(socket.id);
+      const userId = connection?.userId || null;
+      const games = await gameManager.getGameListForLobby(userId);
 
       const gameList = games.map(game => ({
         gameId: game.id,

--- a/apps/server/src/network/socket-handlers.ts
+++ b/apps/server/src/network/socket-handlers.ts
@@ -246,8 +246,11 @@ function registerHandlers(handler: PacketHandler, io: Server, socket: Socket) {
             isNewUser = true;
           } catch (insertError: any) {
             // Handle race condition: username was created by another connection
-            if (insertError?.code === '23505') { // PostgreSQL unique constraint violation
-              logger.debug(`Username ${username} already exists due to race condition, fetching existing user`);
+            if (insertError?.code === '23505') {
+              // PostgreSQL unique constraint violation
+              logger.debug(
+                `Username ${username} already exists due to race condition, fetching existing user`
+              );
               const existingUserRetry = await db.query.users.findFirst({
                 where: eq(users.username, username),
               });
@@ -1317,18 +1320,18 @@ async function sendPlayerMapData(
     logger.warn(`No game instance found for ${gameId}`);
     return;
   }
-  
+
   const mapData = gameInstance.mapManager.getMapData();
   if (!mapData) {
     logger.warn(`No map data found for game ${gameId}`);
     return;
   }
-  
+
   // Use raw map data for basic display (no visibility filtering for now)
   const playerMapView = {
     width: mapData.width,
     height: mapData.height,
-    tiles: mapData.tiles
+    tiles: mapData.tiles,
   };
 
   // Send MAP_INFO packet via structured packet system
@@ -1359,7 +1362,7 @@ async function sendPlayerMapData(
           y: y,
           terrain: tile.terrain,
           known: 1, // Mark all tiles as explored for basic display
-          seen: 1,  // Mark all tiles as visible for basic display
+          seen: 1, // Mark all tiles as visible for basic display
           resource: tile.resource,
         };
 

--- a/apps/server/tests/game/TemperatureFlags.test.ts
+++ b/apps/server/tests/game/TemperatureFlags.test.ts
@@ -123,7 +123,6 @@ describe('TemperatureFlags - Bitwise Operations', () => {
   });
 
   describe('Performance and Binary Analysis', () => {
-
     it('should produce correct binary representations', () => {
       // Verify binary representations match expected patterns
       const binaryTests = [


### PR DESCRIPTION
## Summary
- Simplifies game session storage to only handle username persistence
- Removes legacy multi-key and per-game session storage logic
- Updates GameManager to reject new players if game status is not 'waiting'
- Removes special case allowing player replacement on refresh in active single-player games
- Adds beforeunload event listener in GameRoute to confirm page refresh and warn user about redirection
- Updates game list to use connected player count for running/active games
- Updates player connection status in database on connect/disconnect
- Adds logic to redirect to lobby on page reload in GameRoute
- Passes userId to game list queries to allow rejoin checks
- Updates socket handlers to include gameType when creating games

## Changes

### Client-side
- Refactored `gameSession.ts` to store only a single username key in localStorage
- Removed complex session management and game-type checks
- Updated `GameRoute.tsx` to use new username storage functions
- Added beforeunload event listener in `GameRoute.tsx` to warn users on page refresh
- Added logic in `GameRoute.tsx` to detect page reload and redirect to lobby

### Server-side
- Modified `GameManager.ts` to:
  - Reject new player joins if game status is not 'waiting'
  - Remove logic that allowed replacing existing single player on refresh
  - Use connected player count for running/active games in game list
  - Update player connection status in database on connect/disconnect
  - Pass userId to game list queries to allow rejoin checks
- Added method to get connected player count for a game
- Updated socket handlers to include gameType when creating games

## Test plan
- Verify username is stored and retrieved correctly across sessions
- Confirm that new players cannot join games that are not in 'waiting' status
- Ensure existing players can rejoin ongoing games without issues
- Test that page refresh in single-player games does not cause player replacement
- Verify beforeunload confirmation dialog appears on page refresh
- Verify page reload redirects to lobby
- Verify game list shows connected player counts for running/active games
- Verify player connection status updates in database on connect/disconnect
- Manual and automated tests for localStorage usage, game join restrictions, connection status updates, and game list player counts

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/620d24d0-4b35-41ae-becf-20d2f228d215
