### PR TITLE
Update background color and theme palette to #f8f5f0 base

### DIFF
--- a/apps/client/src/components/shared/PageBackground.tsx
+++ b/apps/client/src/components/shared/PageBackground.tsx
@@ -13,7 +13,7 @@ export const PageBackground: React.FC<PageBackgroundProps> = ({
   showBackground = true,
 }) => {
   const backgroundClasses = clsx(
-    'bg-gradient-to-b from-amber-100 to-yellow-200',
+    'bg-gradient-to-b from-[#fcfaf8] to-[#f8f5f0]',
     {
       // Use md breakpoint (768px) which matches Galaxy Fold5 portrait unfolded mode
       "md:bg-[url('/img/background.png')] md:bg-cover md:bg-center md:bg-no-repeat": showBackground,

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -22,8 +22,8 @@ body {
     'Open Sans',
     'Helvetica Neue',
     sans-serif;
-  background-color: #111827;
-  color: #f9fafb;
+  background-color: #f8f5f0;
+  color: #3e2723;
   overflow: hidden;
 }
 
@@ -45,16 +45,16 @@ canvas {
 }
 
 ::-webkit-scrollbar-track {
-  background: #374151;
+  background: #e0d6c9;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #6b7280;
+  background: #418845;
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #9ca3af;
+  background: #52a554;
 }
 
 @theme inline {
@@ -97,71 +97,71 @@ canvas {
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --background: oklch(0.969 0.01 80.9); /* #f8f5f0 */
+  --foreground: oklch(0.253 0.027 52.9); /* #3e2723 */
+  --card: oklch(0.985 0.005 80.9); /* #fcfaf8 */
+  --card-foreground: oklch(0.253 0.027 52.9); /* #3e2723 */
+  --popover: oklch(0.985 0.005 80.9); /* #fcfaf8 */
+  --popover-foreground: oklch(0.253 0.027 52.9); /* #3e2723 */
+  --primary: oklch(0.516 0.095 145.7); /* #418845 */
+  --primary-foreground: oklch(0.985 0.005 80.9); /* #fcfaf8 */
+  --secondary: oklch(0.924 0.012 80.9); /* #e4e8dd */
+  --secondary-foreground: oklch(0.253 0.027 52.9); /* #3e2723 */
+  --muted: oklch(0.878 0.015 80.9); /* #e0d6c9 */
+  --muted-foreground: oklch(0.45 0.02 52.9);
+  --accent: oklch(0.878 0.015 80.9); /* #e0d6c9 */
+  --accent-foreground: oklch(0.253 0.027 52.9); /* #3e2723 */
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
+  --border: oklch(0.878 0.015 80.9); /* #e0d6c9 */
+  --input: oklch(0.878 0.015 80.9); /* #e0d6c9 */
+  --ring: oklch(0.516 0.095 145.7); /* #418845 */
+  --chart-1: oklch(0.516 0.095 145.7); /* #418845 */
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar: oklch(0.985 0.005 80.9); /* #fcfaf8 */
+  --sidebar-foreground: oklch(0.253 0.027 52.9); /* #3e2723 */
+  --sidebar-primary: oklch(0.516 0.095 145.7); /* #418845 */
+  --sidebar-primary-foreground: oklch(0.985 0.005 80.9); /* #fcfaf8 */
+  --sidebar-accent: oklch(0.924 0.012 80.9); /* #e4e8dd */
+  --sidebar-accent-foreground: oklch(0.253 0.027 52.9); /* #3e2723 */
+  --sidebar-border: oklch(0.878 0.015 80.9); /* #e0d6c9 */
+  --sidebar-ring: oklch(0.516 0.095 145.7); /* #418845 */
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  --background: oklch(0.253 0.027 52.9); /* #3e2723 - darker version */
+  --foreground: oklch(0.985 0.005 80.9); /* #fcfaf8 */
+  --card: oklch(0.3 0.03 52.9); /* Darker card */
+  --card-foreground: oklch(0.985 0.005 80.9); /* #fcfaf8 */
+  --popover: oklch(0.3 0.03 52.9);
+  --popover-foreground: oklch(0.985 0.005 80.9); /* #fcfaf8 */
+  --primary: oklch(0.516 0.095 145.7); /* #418845 */
+  --primary-foreground: oklch(0.985 0.005 80.9); /* #fcfaf8 */
+  --secondary: oklch(0.4 0.03 52.9); /* Darker secondary */
+  --secondary-foreground: oklch(0.985 0.005 80.9); /* #fcfaf8 */
+  --muted: oklch(0.4 0.03 52.9);
+  --muted-foreground: oklch(0.708 0.02 80.9);
+  --accent: oklch(0.4 0.03 52.9);
+  --accent-foreground: oklch(0.985 0.005 80.9); /* #fcfaf8 */
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
+  --border: oklch(0.4 0.03 52.9);
+  --input: oklch(0.45 0.03 52.9);
+  --ring: oklch(0.516 0.095 145.7); /* #418845 */
+  --chart-1: oklch(0.516 0.095 145.7); /* #418845 */
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar: oklch(0.3 0.03 52.9);
+  --sidebar-foreground: oklch(0.985 0.005 80.9); /* #fcfaf8 */
+  --sidebar-primary: oklch(0.516 0.095 145.7); /* #418845 */
+  --sidebar-primary-foreground: oklch(0.985 0.005 80.9); /* #fcfaf8 */
+  --sidebar-accent: oklch(0.4 0.03 52.9);
+  --sidebar-accent-foreground: oklch(0.985 0.005 80.9); /* #fcfaf8 */
+  --sidebar-border: oklch(0.4 0.03 52.9);
+  --sidebar-ring: oklch(0.516 0.095 145.7); /* #418845 */
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- Updated the default background color to a soft off-white shade (#f8f5f0) for a lighter, warmer UI appearance.
- Modified the page background gradient to transition from #fcfaf8 to #f8f5f0.
- Adjusted CSS variables for light and dark themes to align with the new color palette, improving visual consistency.
- Updated scrollbar colors and text colors to complement the new background.

## Changes

### Styling
- **PageBackground.tsx**: Changed background gradient colors to use #fcfaf8 and #f8f5f0.
- **index.css**:
  - Set `body` background-color to #f8f5f0 and text color to a dark brown (#3e2723).
  - Updated scrollbar track and thumb colors to lighter, natural tones.
  - Refined CSS custom properties (`:root` and `.dark`) to use colors matching the new background and foreground scheme.
  - Adjusted card, popover, primary, secondary, muted, accent, sidebar, border, input, and ring colors for both light and dark themes.

## Test plan
- [x] Verify the background gradient renders correctly on the page.
- [x] Confirm the body background and text colors update as expected.
- [x] Check that all theme variables reflect the new color palette in both light and dark modes.
- [x] Ensure scrollbar styling matches the updated colors.
- [x] Test UI components for visual consistency and readability with the new colors.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3f18201f-81ab-48be-a6e6-e0cdd0cdad15