### PR TITLE
Split unit test runs for client and server in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,11 @@ jobs:
         env:
           DATABASE_URL: postgresql://ci_test_user:ci_test_password_123@localhost:5432/civjs_test
       
-      - name: Run unit tests
-        run: |
-          cd apps/client && npm run test
-          cd apps/server && npm run test:unit -- --ci --coverage --maxWorkers=2
+      - name: Run client unit tests
+        run: cd apps/client && npm run test
+      
+      - name: Run server unit tests
+        run: cd apps/server && npm run test:unit -- --ci --coverage --maxWorkers=2
       
       - name: Run integration tests
         run: cd apps/server && npm run test:integration -- --ci --coverage --maxWorkers=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,9 @@ jobs:
           DATABASE_URL: postgresql://ci_test_user:ci_test_password_123@localhost:5432/civjs_test
       
       - name: Run unit tests
-        run: npm run test:unit -- --ci --coverage --maxWorkers=2
+        run: |
+          cd apps/client && npm run test
+          cd apps/server && npm run test:unit -- --ci --coverage --maxWorkers=2
       
       - name: Run integration tests
         run: cd apps/server && npm run test:integration -- --ci --coverage --maxWorkers=1


### PR DESCRIPTION
## Summary
- Updates the CI workflow to run unit tests separately for client and server applications
- Ensures client tests run in `apps/client` directory
- Runs server unit tests with coverage and concurrency options in `apps/server` directory

## Changes

### CI Workflow
- Modified `.github/workflows/ci.yml`:
  - Replaced single unit test command with two commands:
    - `cd apps/client && npm run test` for client-side tests
    - `cd apps/server && npm run test:unit -- --ci --coverage --maxWorkers=2` for server-side unit tests

## Test plan
- [x] Verify CI workflow triggers and completes successfully
- [x] Confirm client tests run and pass
- [x] Confirm server unit tests run with coverage and pass
- [x] Ensure integration tests remain unaffected and run as before

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/590e5dc8-b28e-4d21-83eb-2ea439d9004a