### PR TITLE
Add CI step to update server coverage badge via PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,25 @@ jobs:
           report_path: coverage/coverage-summary.json
           output_path: ../../server-coverage-badge.svg
 
+      - name: Verify Changed files
+        uses: tj-actions/verify-changed-files@v20
+        id: verify-changed-files
+        if: always()
+        with:
+          files: |
+             server-coverage-badge.svg
+
+      - name: Create Pull Request
+        if: steps.verify-changed-files.outputs.files_changed == 'true' && github.ref == 'refs/heads/master'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          base: "master"
+          title: "Updated server coverage badge"
+          branch: "chore/update-server-coverage-badge"
+          commit-message: "Updated server coverage badge."
+          body: "Updated server coverage badge."
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Summary
- Adds a new step in the CI workflow to verify if the server coverage badge SVG has changed
- Automatically creates a pull request to update the server coverage badge on the master branch

## Changes

### CI Workflow Updates
- Added `Verify Changed files` step using `tj-actions/verify-changed-files` to check if `server-coverage-badge.svg` was modified
- Added conditional `Create Pull Request` step using `peter-evans/create-pull-request` to open a PR titled "Updated server coverage badge" when the badge file changes on the master branch

## Test plan
- Confirm that the CI workflow runs the new verification step
- Validate that a PR is created automatically when the coverage badge SVG changes on master branch
- Ensure no PR is created if the badge file is unchanged or on other branches

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/2fdda68f-c742-444a-bd41-e0b104c76c40