### PR TITLE
Add CityInfoOverlay component to display city details on right-click

### DIFF
--- a/apps/client/package-lock.json
+++ b/apps/client/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.3",
         "@tailwindcss/postcss": "^4.1.12",
@@ -1616,6 +1617,29 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -9460,6 +9484,14 @@
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.2.2"
+      }
+    },
+    "@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "requires": {
+        "@radix-ui/react-primitive": "2.1.3"
       }
     },
     "@radix-ui/react-slider": {

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/postcss": "^4.1.12",

--- a/apps/client/src/components/Canvas2D/MapCanvas.tsx
+++ b/apps/client/src/components/Canvas2D/MapCanvas.tsx
@@ -4,7 +4,8 @@ import { MapRenderer } from './MapRenderer';
 import { TileHoverOverlay } from './TileHoverOverlay';
 import { UnitContextMenu } from '../GameUI/UnitContextMenu';
 import { CityNameDialog } from '../GameUI/CityNameDialog';
-import type { Unit } from '../../types';
+import { CityInfoOverlay } from '../GameUI/CityInfoOverlay';
+import type { Unit, City } from '../../types';
 import { ActionType } from '../../types/shared/actions';
 import { gameClient } from '../../services/GameClient';
 import { pathfindingService, type GotoPath } from '../../services/PathfindingService';
@@ -38,6 +39,15 @@ export const MapCanvas: React.FC<MapCanvasProps> = ({ width, height }) => {
   }>({
     isOpen: false,
     unit: null,
+  });
+
+  // City info overlay state
+  const [cityInfoOverlay, setCityInfoOverlay] = useState<{
+    isOpen: boolean;
+    city: City | null;
+  }>({
+    isOpen: false,
+    city: null,
   });
 
   // Goto mode state (similar to freeciv-web's goto_active)
@@ -769,6 +779,11 @@ export const MapCanvas: React.FC<MapCanvasProps> = ({ width, height }) => {
         unit => unit.x === tileX && unit.y === tileY
       );
 
+      // Find city at right-clicked position
+      const cityAtPosition = Object.values(cities).find(
+        city => city.x === tileX && city.y === tileY
+      );
+
       if (unitAtPosition) {
         // Show context menu for the unit
         setContextMenu({
@@ -777,9 +792,15 @@ export const MapCanvas: React.FC<MapCanvasProps> = ({ width, height }) => {
         });
         selectUnit(unitAtPosition.id);
         setSelectedUnit(unitAtPosition as Unit);
+      } else if (cityAtPosition) {
+        // Show info overlay for the city
+        setCityInfoOverlay({
+          isOpen: true,
+          city: cityAtPosition as City,
+        });
       }
     },
-    [selectUnit, units, viewport, gotoMode.active, deactivateGotoMode]
+    [selectUnit, units, cities, viewport, gotoMode.active, deactivateGotoMode]
   );
 
   // Handle unit action selection
@@ -865,6 +886,13 @@ export const MapCanvas: React.FC<MapCanvasProps> = ({ width, height }) => {
     setCityNameDialog({
       isOpen: false,
       unit: null,
+    });
+  }, []);
+
+  const handleCloseCityInfoOverlay = useCallback(() => {
+    setCityInfoOverlay({
+      isOpen: false,
+      city: null,
     });
   }, []);
 
@@ -988,6 +1016,12 @@ export const MapCanvas: React.FC<MapCanvasProps> = ({ width, height }) => {
         unit={cityNameDialog.unit}
         onClose={handleCloseCityNameDialog}
         onFoundCity={handleFoundCity}
+      />
+
+      <CityInfoOverlay
+        city={cityInfoOverlay.city}
+        isOpen={cityInfoOverlay.isOpen}
+        onClose={handleCloseCityInfoOverlay}
       />
     </div>
   );

--- a/apps/client/src/components/GameUI/CityInfoOverlay.tsx
+++ b/apps/client/src/components/GameUI/CityInfoOverlay.tsx
@@ -1,22 +1,8 @@
 import React from 'react';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '../ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../ui/dialog';
 import { Badge } from '../ui/badge';
 import { Separator } from '../ui/separator';
-import {
-  Building2,
-  Users,
-  Wheat,
-  Shield,
-  TrendingUp,
-  Hammer,
-  MapPin,
-} from 'lucide-react';
+import { Building2, Users, Wheat, Shield, TrendingUp, Hammer, MapPin } from 'lucide-react';
 import type { City } from '../../types';
 
 interface CityInfoOverlayProps {
@@ -27,7 +13,7 @@ interface CityInfoOverlayProps {
 
 /**
  * CityInfoOverlay displays detailed information about a city when right-clicked.
- * 
+ *
  * Based on freeciv-web's show_city_dialog functionality:
  * @reference freeciv-web/freeciv-web/src/main/webapp/javascript/city.js:138-226
  * - Shows city name and size in title
@@ -35,11 +21,7 @@ interface CityInfoOverlayProps {
  * - Lists buildings and current production
  * - Shows city position
  */
-export const CityInfoOverlay: React.FC<CityInfoOverlayProps> = ({
-  city,
-  isOpen,
-  onClose,
-}) => {
+export const CityInfoOverlay: React.FC<CityInfoOverlayProps> = ({ city, isOpen, onClose }) => {
   if (!city) {
     return null;
   }
@@ -130,7 +112,10 @@ export const CityInfoOverlay: React.FC<CityInfoOverlayProps> = ({
                     <div className="text-xs text-muted-foreground">
                       {Math.max(
                         0,
-                        Math.ceil((city.production.cost - city.production.progress) / Math.max(1, city.shields))
+                        Math.ceil(
+                          (city.production.cost - city.production.progress) /
+                            Math.max(1, city.shields)
+                        )
                       )}{' '}
                       turns remaining
                     </div>

--- a/apps/client/src/components/GameUI/CityInfoOverlay.tsx
+++ b/apps/client/src/components/GameUI/CityInfoOverlay.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import { Badge } from '../ui/badge';
+import { Separator } from '../ui/separator';
+import {
+  Building2,
+  Users,
+  Wheat,
+  Shield,
+  TrendingUp,
+  Hammer,
+  MapPin,
+} from 'lucide-react';
+import type { City } from '../../types';
+
+interface CityInfoOverlayProps {
+  city: City | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * CityInfoOverlay displays detailed information about a city when right-clicked.
+ * 
+ * Based on freeciv-web's show_city_dialog functionality:
+ * @reference freeciv-web/freeciv-web/src/main/webapp/javascript/city.js:138-226
+ * - Shows city name and size in title
+ * - Displays resource output (food, shields, trade)
+ * - Lists buildings and current production
+ * - Shows city position
+ */
+export const CityInfoOverlay: React.FC<CityInfoOverlayProps> = ({
+  city,
+  isOpen,
+  onClose,
+}) => {
+  if (!city) {
+    return null;
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Building2 className="h-5 w-5" />
+            {city.name}
+          </DialogTitle>
+          <DialogDescription>
+            <div className="flex items-center gap-4 text-sm text-muted-foreground">
+              <div className="flex items-center gap-1">
+                <MapPin className="h-4 w-4" />
+                Position ({city.x}, {city.y})
+              </div>
+              <div className="flex items-center gap-1">
+                <Users className="h-4 w-4" />
+                Size {city.size}
+              </div>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Resource Output Section */}
+          <div>
+            <h3 className="text-sm font-medium mb-3 flex items-center gap-2">
+              <TrendingUp className="h-4 w-4" />
+              Resource Output
+            </h3>
+            <div className="grid grid-cols-3 gap-3">
+              <div className="flex flex-col items-center p-3 bg-green-50 rounded-lg border">
+                <Wheat className="h-5 w-5 text-green-600 mb-1" />
+                <div className="text-lg font-semibold text-green-700">{city.food}</div>
+                <div className="text-xs text-green-600">Food</div>
+              </div>
+              <div className="flex flex-col items-center p-3 bg-blue-50 rounded-lg border">
+                <Shield className="h-5 w-5 text-blue-600 mb-1" />
+                <div className="text-lg font-semibold text-blue-700">{city.shields}</div>
+                <div className="text-xs text-blue-600">Shields</div>
+              </div>
+              <div className="flex flex-col items-center p-3 bg-yellow-50 rounded-lg border">
+                <TrendingUp className="h-5 w-5 text-yellow-600 mb-1" />
+                <div className="text-lg font-semibold text-yellow-700">{city.trade}</div>
+                <div className="text-xs text-yellow-600">Trade</div>
+              </div>
+            </div>
+          </div>
+
+          <Separator />
+
+          {/* Production Section */}
+          {city.production && (
+            <>
+              <div>
+                <h3 className="text-sm font-medium mb-3 flex items-center gap-2">
+                  <Hammer className="h-4 w-4" />
+                  Current Production
+                </h3>
+                <div className="p-3 bg-gray-50 rounded-lg border">
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="font-medium">{city.production.target}</span>
+                    <Badge variant="secondary" className="capitalize">
+                      {city.production.type}
+                    </Badge>
+                  </div>
+                  <div className="space-y-1">
+                    <div className="flex justify-between text-sm">
+                      <span>Progress:</span>
+                      <span>
+                        {city.production.progress} / {city.production.cost}
+                      </span>
+                    </div>
+                    <div className="w-full bg-gray-200 rounded-full h-2">
+                      <div
+                        className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+                        style={{
+                          width: `${Math.min(
+                            (city.production.progress / city.production.cost) * 100,
+                            100
+                          )}%`,
+                        }}
+                      />
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {Math.max(
+                        0,
+                        Math.ceil((city.production.cost - city.production.progress) / Math.max(1, city.shields))
+                      )}{' '}
+                      turns remaining
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <Separator />
+            </>
+          )}
+
+          {/* Buildings Section */}
+          {city.buildings.length > 0 && (
+            <div>
+              <h3 className="text-sm font-medium mb-3 flex items-center gap-2">
+                <Building2 className="h-4 w-4" />
+                Buildings ({city.buildings.length})
+              </h3>
+              <div className="space-y-2 max-h-32 overflow-y-auto">
+                {city.buildings.map((building, index) => (
+                  <div
+                    key={index}
+                    className="flex items-center justify-between p-2 bg-gray-50 rounded border"
+                  >
+                    <span className="text-sm">{building}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/client/src/components/ui/badge.tsx
+++ b/apps/client/src/components/ui/badge.tsx
@@ -1,36 +1,33 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { cn } from "../../lib/utils"
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        default: 'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
         secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
         destructive:
-          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
-        outline: "text-foreground",
+          'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
+        outline: 'text-foreground',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
   }
-)
+);
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
 export function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  )
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
-export { badgeVariants }
+export { badgeVariants };

--- a/apps/client/src/components/ui/badge.tsx
+++ b/apps/client/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "../../lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+export function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export { badgeVariants }

--- a/apps/client/src/components/ui/separator.tsx
+++ b/apps/client/src/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+import { cn } from "../../lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/apps/client/src/components/ui/separator.tsx
+++ b/apps/client/src/components/ui/separator.tsx
@@ -1,28 +1,23 @@
-import * as React from "react"
-import * as SeparatorPrimitive from "@radix-ui/react-separator"
-import { cn } from "../../lib/utils"
+import * as React from 'react';
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
+import { cn } from '../../lib/utils';
 
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
->(
-  (
-    { className, orientation = "horizontal", decorative = true, ...props },
-    ref
-  ) => (
-    <SeparatorPrimitive.Root
-      ref={ref}
-      decorative={decorative}
-      orientation={orientation}
-      className={cn(
-        "shrink-0 bg-border",
-        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
-        className
-      )}
-      {...props}
-    />
-  )
-)
-Separator.displayName = SeparatorPrimitive.Root.displayName
+>(({ className, orientation = 'horizontal', decorative = true, ...props }, ref) => (
+  <SeparatorPrimitive.Root
+    ref={ref}
+    decorative={decorative}
+    orientation={orientation}
+    className={cn(
+      'shrink-0 bg-border',
+      orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+      className
+    )}
+    {...props}
+  />
+));
+Separator.displayName = SeparatorPrimitive.Root.displayName;
 
-export { Separator }
+export { Separator };


### PR DESCRIPTION
## Summary
- Introduces a new `CityInfoOverlay` component to show detailed city information when a city is right-clicked on the map.
- Adds UI elements to display city name, position, size, resource output (food, shields, trade), current production progress, and buildings.
- Integrates the overlay into the `MapCanvas` component with state management for opening and closing.
- Adds new UI components `Badge` and `Separator` for consistent styling.
- Adds `@radix-ui/react-separator` dependency for the separator UI component.

## Changes

### Core Functionality
- Created `CityInfoOverlay.tsx` to render city details in a dialog overlay.
- Updated `MapCanvas.tsx` to track city info overlay state and open it on right-clicking a city tile.
- Added handler to close the city info overlay.

### UI Components
- Added `Badge` component for displaying production type badges.
- Added `Separator` component for visual separation in dialogs.

### Dependencies
- Added `@radix-ui/react-separator` package for the separator component.

## Test plan
- [x] Right-click on a city tile opens the city info overlay.
- [x] Overlay displays correct city name, position, size, resource output, production, and buildings.
- [x] Overlay can be closed properly.
- [x] UI components render correctly with consistent styling.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9c9af7b0-5f2e-4a6c-816e-b3a9af4a3cdc