### PR TITLE
Fix random nation display by updating player nation on join event

### DIFF
--- a/apps/client/package-lock.json
+++ b/apps/client/package-lock.json
@@ -8095,6 +8095,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/apps/client/src/services/GameClient.ts
+++ b/apps/client/src/services/GameClient.ts
@@ -146,6 +146,30 @@ class GameClient {
     // Legacy event handlers removed - now handled via structured packets
 
     // Keep compatibility events for game management
+    
+    // Handle player joined events to update nation information
+    this.socket.on('player-joined', data => {
+      console.log('Player joined:', data);
+      const { players, currentPlayerId } = useGameStore.getState();
+      
+      // Update the current player's nation if this is the current player
+      if (currentPlayerId === data.playerId && players[data.playerId]) {
+        const updatedPlayer = {
+          ...players[data.playerId],
+          nation: data.civilization, // Update nation from "random" to actual selected nation
+        };
+        
+        useGameStore.getState().updateGameState({
+          players: {
+            ...players,
+            [data.playerId]: updatedPlayer,
+          },
+        });
+        
+        console.log(`Updated player ${data.playerId} nation from "${players[data.playerId].nation}" to "${data.civilization}"`);
+      }
+    });
+
     this.socket.on('game_created', data => {
       console.log('Game created:', data);
 


### PR DESCRIPTION
## Summary
- Fixes issue where players initially show a "random" nation by updating the nation to the actual selected civilization when a player joins
- Adds event handler for `player-joined` socket event to update the current player's nation in the game state
- Ensures the UI reflects the correct nation instead of the placeholder "random"

## Changes

### GameClient Service
- Added a new socket event listener for `player-joined`:
  - Logs the player join event for debugging
  - Checks if the joined player is the current player
  - Updates the player's nation from "random" to the actual civilization selected
  - Updates the game state with the new player nation
  - Logs the nation update for traceability

### Package Lock
- Added license field to the TypeScript package entry in `package-lock.json` for compliance

## Test plan
- [x] Join a game as a new player and verify the nation updates from "random" to the selected civilization
- [x] Confirm no regressions in game creation and other socket events
- [x] Check console logs for player join and nation update messages

This change improves the accuracy of player nation display and enhances the user experience by reflecting the correct civilization immediately upon joining.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6892a691-bc72-43a2-85c8-992b70d08af6