### PR TITLE
feat(playerColors): add nation color themes with 3-color palettes and…

### DIFF
--- a/apps/server/src/game/orchestrators/PlayerConnectionManager.ts
+++ b/apps/server/src/game/orchestrators/PlayerConnectionManager.ts
@@ -95,8 +95,15 @@ export class PlayerConnectionManager extends BaseGameService implements PlayerCo
     const selectedNation = await this.validateAndSelectNation(civilization, game.players);
 
     // Get next available color from predefined palette
+    // TODO: Upgrade to use full 3-color themes when UI supports it
     const usedColors = game.players.map(p => p.color as PlayerColor);
     const assignedColor = getNextPlayerColor(usedColors);
+
+    // For future reference - how to get a full color theme:
+    // import { getNextPlayerColorTheme, type NationColorTheme } from '../../utils/playerColors';
+    // const usedThemes = game.players.map(p => ({ primary: p.color } as NationColorTheme));
+    // const assignedTheme = getNextPlayerColorTheme(usedThemes);
+    // const assignedColor = assignedTheme.primary;
 
     const playerData = {
       gameId,

--- a/apps/server/src/utils/playerColors.ts
+++ b/apps/server/src/utils/playerColors.ts
@@ -1,6 +1,6 @@
 /**
- * Standard player colors for consistent appearance across server and client
- * These colors are chosen to be distinct and work well in the game UI
+ * Nation color system with 3-color themes for visual distinction
+ * Colors are chosen to be distinct, historically appropriate, and avoid ocean-like blues
  */
 
 export interface PlayerColor {
@@ -9,20 +9,119 @@ export interface PlayerColor {
   b: number;
 }
 
-export const PLAYER_COLORS: PlayerColor[] = [
-  { r: 255, g: 69, b: 0 }, // Red-Orange
-  { r: 30, g: 144, b: 255 }, // Dodge Blue
-  { r: 50, g: 205, b: 50 }, // Lime Green
-  { r: 255, g: 215, b: 0 }, // Gold
-  { r: 138, g: 43, b: 226 }, // Blue Violet
-  { r: 255, g: 20, b: 147 }, // Deep Pink
-  { r: 0, g: 191, b: 255 }, // Deep Sky Blue
-  { r: 255, g: 140, b: 0 }, // Dark Orange
-  { r: 124, g: 252, b: 0 }, // Lawn Green
-  { r: 220, g: 20, b: 60 }, // Crimson
-  { r: 0, g: 255, b: 255 }, // Cyan
-  { r: 255, g: 105, b: 180 }, // Hot Pink
+export interface NationColorTheme {
+  primary: PlayerColor; // Main color for borders, units, UI elements
+  secondary: PlayerColor; // Secondary color for text, highlights
+  tertiary: PlayerColor; // Accent color for special elements
+  name: string; // Theme name for debugging
+}
+
+/**
+ * Predefined nation color themes - avoiding ocean-like blues
+ * Each theme has primary, secondary, and tertiary colors
+ */
+export const NATION_COLOR_THEMES: NationColorTheme[] = [
+  // Classic Empire Colors
+  {
+    name: 'Roman Red',
+    primary: { r: 204, g: 0, b: 0 }, // Deep Red
+    secondary: { r: 255, g: 215, b: 0 }, // Gold
+    tertiary: { r: 139, g: 69, b: 19 }, // Saddle Brown
+  },
+  {
+    name: 'Imperial Purple',
+    primary: { r: 138, g: 43, b: 226 }, // Blue Violet
+    secondary: { r: 255, g: 255, b: 255 }, // White
+    tertiary: { r: 255, g: 215, b: 0 }, // Gold
+  },
+  {
+    name: 'Forest Green',
+    primary: { r: 34, g: 139, b: 34 }, // Forest Green
+    secondary: { r: 255, g: 255, b: 255 }, // White
+    tertiary: { r: 139, g: 69, b: 19 }, // Saddle Brown
+  },
+  {
+    name: 'Royal Gold',
+    primary: { r: 255, g: 215, b: 0 }, // Gold
+    secondary: { r: 139, g: 0, b: 0 }, // Dark Red
+    tertiary: { r: 0, g: 0, b: 0 }, // Black
+  },
+  {
+    name: 'Crimson Empire',
+    primary: { r: 220, g: 20, b: 60 }, // Crimson
+    secondary: { r: 255, g: 255, b: 255 }, // White
+    tertiary: { r: 255, g: 215, b: 0 }, // Gold
+  },
+  {
+    name: 'Bright Azure',
+    primary: { r: 0, g: 127, b: 255 }, // Bright Blue (not ocean-like)
+    secondary: { r: 255, g: 255, b: 255 }, // White
+    tertiary: { r: 255, g: 215, b: 0 }, // Gold
+  },
+  {
+    name: 'Orange Dynasty',
+    primary: { r: 255, g: 140, b: 0 }, // Dark Orange
+    secondary: { r: 0, g: 0, b: 0 }, // Black
+    tertiary: { r: 255, g: 255, b: 255 }, // White
+  },
+  {
+    name: 'Emerald Kingdom',
+    primary: { r: 0, g: 201, b: 87 }, // Emerald Green
+    secondary: { r: 255, g: 255, b: 255 }, // White
+    tertiary: { r: 139, g: 69, b: 19 }, // Saddle Brown
+  },
+  {
+    name: 'Magenta Empire',
+    primary: { r: 255, g: 0, b: 255 }, // Magenta
+    secondary: { r: 255, g: 255, b: 255 }, // White
+    tertiary: { r: 0, g: 0, b: 0 }, // Black
+  },
+  {
+    name: 'Copper Bronze',
+    primary: { r: 184, g: 115, b: 51 }, // Copper
+    secondary: { r: 255, g: 255, b: 255 }, // White
+    tertiary: { r: 139, g: 0, b: 0 }, // Dark Red
+  },
+  {
+    name: 'Silver Steel',
+    primary: { r: 192, g: 192, b: 192 }, // Silver
+    secondary: { r: 0, g: 0, b: 0 }, // Black
+    tertiary: { r: 0, g: 127, b: 255 }, // Bright Blue
+  },
+  {
+    name: 'Rose Kingdom',
+    primary: { r: 255, g: 20, b: 147 }, // Deep Pink
+    secondary: { r: 255, g: 255, b: 255 }, // White
+    tertiary: { r: 139, g: 0, b: 139 }, // Dark Magenta
+  },
+  {
+    name: 'Amber Empire',
+    primary: { r: 255, g: 191, b: 0 }, // Amber
+    secondary: { r: 139, g: 69, b: 19 }, // Saddle Brown
+    tertiary: { r: 255, g: 255, b: 255 }, // White
+  },
+  {
+    name: 'Jade Dynasty',
+    primary: { r: 0, g: 168, b: 107 }, // Jade Green
+    secondary: { r: 255, g: 215, b: 0 }, // Gold
+    tertiary: { r: 139, g: 0, b: 0 }, // Dark Red
+  },
+  {
+    name: 'Violet Reign',
+    primary: { r: 148, g: 0, b: 211 }, // Dark Violet
+    secondary: { r: 255, g: 255, b: 255 }, // White
+    tertiary: { r: 255, g: 215, b: 0 }, // Gold
+  },
+  {
+    name: 'Coral Empire',
+    primary: { r: 255, g: 127, b: 80 }, // Coral
+    secondary: { r: 255, g: 255, b: 255 }, // White
+    tertiary: { r: 0, g: 0, b: 139 }, // Dark Blue
+  },
 ];
+
+// Legacy support - primary colors only for backward compatibility
+export const PLAYER_COLORS: PlayerColor[] = NATION_COLOR_THEMES.map(theme => theme.primary);
 
 /**
  * Convert PlayerColor object to CSS hex string
@@ -46,7 +145,30 @@ export function hexToPlayerColor(hex: string): PlayerColor {
 }
 
 /**
- * Get the next available color for a new player
+ * Get the next available color theme for a new player
+ * @param usedThemes - Array of color themes already in use
+ * @returns Next available color theme, or a random one if all are used
+ */
+export function getNextPlayerColorTheme(usedThemes: NationColorTheme[]): NationColorTheme {
+  // Find the first unused theme
+  for (const theme of NATION_COLOR_THEMES) {
+    const isUsed = usedThemes.some(
+      used =>
+        used.primary.r === theme.primary.r &&
+        used.primary.g === theme.primary.g &&
+        used.primary.b === theme.primary.b
+    );
+    if (!isUsed) {
+      return theme;
+    }
+  }
+
+  // If all predefined themes are used, return a random one from the palette
+  return NATION_COLOR_THEMES[Math.floor(Math.random() * NATION_COLOR_THEMES.length)];
+}
+
+/**
+ * Legacy function - Get the next available primary color for a new player
  * @param usedColors - Array of colors already in use
  * @returns Next available color, or a random color if all are used
  */
@@ -63,4 +185,26 @@ export function getNextPlayerColor(usedColors: PlayerColor[]): PlayerColor {
 
   // If all predefined colors are used, return a random one from the palette
   return PLAYER_COLORS[Math.floor(Math.random() * PLAYER_COLORS.length)];
+}
+
+/**
+ * Convert NationColorTheme to CSS hex strings
+ */
+export function colorThemeToHex(theme: NationColorTheme): {
+  primary: string;
+  secondary: string;
+  tertiary: string;
+} {
+  return {
+    primary: playerColorToHex(theme.primary),
+    secondary: playerColorToHex(theme.secondary),
+    tertiary: playerColorToHex(theme.tertiary),
+  };
+}
+
+/**
+ * Get a color theme by name (for debugging/testing)
+ */
+export function getColorThemeByName(name: string): NationColorTheme | null {
+  return NATION_COLOR_THEMES.find(theme => theme.name === name) || null;
 }

--- a/color-demo.html
+++ b/color-demo.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CivJS Nation Color Themes</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; background: #1a1a1a; color: white; }
+        .theme-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 20px; }
+        .theme-card { 
+            border: 2px solid #333; 
+            border-radius: 8px; 
+            padding: 15px; 
+            background: #2a2a2a;
+        }
+        .color-row { display: flex; align-items: center; margin: 8px 0; }
+        .color-swatch { 
+            width: 40px; 
+            height: 40px; 
+            border-radius: 4px; 
+            margin-right: 10px; 
+            border: 1px solid #666;
+        }
+        .color-info { flex: 1; }
+        .color-label { font-weight: bold; margin-bottom: 4px; }
+        .color-hex { font-family: monospace; color: #ccc; font-size: 0.9em; }
+        h1 { text-align: center; color: #4CAF50; }
+        h2 { margin-top: 0; color: #FFD700; }
+        .ocean-note { 
+            background: #2d3748; 
+            border-left: 4px solid #4299e1; 
+            padding: 15px; 
+            margin: 20px 0;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <h1>🎨 CivJS Nation Color Themes</h1>
+    
+    <div class="ocean-note">
+        <strong>🌊 Ocean Color Consideration:</strong> 
+        All themes avoid ocean-like blues (#30699x, #0088cc) for better visibility on the game map. 
+        We use bright blues (#007fff) that stand out clearly from water.
+    </div>
+
+    <div class="theme-grid" id="themes"></div>
+
+    <script>
+        // Nation color themes from our TypeScript file
+        const themes = [
+            { name: 'Roman Red', primary: [204, 0, 0], secondary: [255, 215, 0], tertiary: [139, 69, 19] },
+            { name: 'Imperial Purple', primary: [138, 43, 226], secondary: [255, 255, 255], tertiary: [255, 215, 0] },
+            { name: 'Forest Green', primary: [34, 139, 34], secondary: [255, 255, 255], tertiary: [139, 69, 19] },
+            { name: 'Royal Gold', primary: [255, 215, 0], secondary: [139, 0, 0], tertiary: [0, 0, 0] },
+            { name: 'Crimson Empire', primary: [220, 20, 60], secondary: [255, 255, 255], tertiary: [255, 215, 0] },
+            { name: 'Bright Azure', primary: [0, 127, 255], secondary: [255, 255, 255], tertiary: [255, 215, 0] },
+            { name: 'Orange Dynasty', primary: [255, 140, 0], secondary: [0, 0, 0], tertiary: [255, 255, 255] },
+            { name: 'Emerald Kingdom', primary: [0, 201, 87], secondary: [255, 255, 255], tertiary: [139, 69, 19] },
+            { name: 'Magenta Empire', primary: [255, 0, 255], secondary: [255, 255, 255], tertiary: [0, 0, 0] },
+            { name: 'Copper Bronze', primary: [184, 115, 51], secondary: [255, 255, 255], tertiary: [139, 0, 0] },
+            { name: 'Silver Steel', primary: [192, 192, 192], secondary: [0, 0, 0], tertiary: [0, 127, 255] },
+            { name: 'Rose Kingdom', primary: [255, 20, 147], secondary: [255, 255, 255], tertiary: [139, 0, 139] },
+            { name: 'Amber Empire', primary: [255, 191, 0], secondary: [139, 69, 19], tertiary: [255, 255, 255] },
+            { name: 'Jade Dynasty', primary: [0, 168, 107], secondary: [255, 215, 0], tertiary: [139, 0, 0] },
+            { name: 'Violet Reign', primary: [148, 0, 211], secondary: [255, 255, 255], tertiary: [255, 215, 0] },
+            { name: 'Coral Empire', primary: [255, 127, 80], secondary: [255, 255, 255], tertiary: [0, 0, 139] }
+        ];
+
+        function rgbToHex(r, g, b) {
+            return "#" + [r, g, b].map(x => x.toString(16).padStart(2, '0')).join('');
+        }
+
+        function createThemeCard(theme) {
+            const colors = [
+                { label: 'Primary', color: theme.primary, desc: 'Borders, units, main UI' },
+                { label: 'Secondary', color: theme.secondary, desc: 'Text, highlights' },
+                { label: 'Tertiary', color: theme.tertiary, desc: 'Accents, special elements' }
+            ];
+
+            return `
+                <div class="theme-card">
+                    <h2>${theme.name}</h2>
+                    ${colors.map(({ label, color, desc }) => `
+                        <div class="color-row">
+                            <div class="color-swatch" style="background-color: rgb(${color.join(',')})"></div>
+                            <div class="color-info">
+                                <div class="color-label">${label}</div>
+                                <div class="color-hex">${rgbToHex(...color)} • ${desc}</div>
+                            </div>
+                        </div>
+                    `).join('')}
+                </div>
+            `;
+        }
+
+        document.getElementById('themes').innerHTML = themes.map(createThemeCard).join('');
+    </script>
+</body>
+</html>


### PR DESCRIPTION
… demo

- Introduce NationColorTheme interface with primary, secondary, tertiary colors
- Define multiple distinct nation color themes avoiding ocean-like blues
- Provide functions to get next available color theme and convert themes to hex
- Update PlayerConnectionManager to prepare for future use of full color themes
- Add legacy support for primary colors for backward compatibility
- Add color-demo.html to visually showcase all nation color themes

This enhancement improves visual distinction and thematic consistency for player colors in the game.