### PR TITLE
Add history_interest_pml column and rename culture_per_turn to history

### DIFF
--- a/apps/server/drizzle/0001_add_history_interest_pml_and_rename_culture_column.sql
+++ b/apps/server/drizzle/0001_add_history_interest_pml_and_rename_culture_column.sql
@@ -1,0 +1,5 @@
+-- Add history_interest_pml column to games table
+ALTER TABLE "games" ADD COLUMN "history_interest_pml" integer DEFAULT 0 NOT NULL;
+
+-- Rename culture_per_turn to history in cities table  
+ALTER TABLE "cities" RENAME COLUMN "culture_per_turn" TO "history";

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1757632409732,
       "tag": "0000_square_logan",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1757895613000,
+      "tag": "0001_add_history_interest_pml_and_rename_culture_column",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a new column `history_interest_pml` to the `games` table with a default value of 0
- Renames the `culture_per_turn` column to `history` in the `cities` table
- Updates the migration journal to include this new migration step

## Changes

### Database Migrations
- **New Column**: Added `history_interest_pml` integer column to `games` table, defaulting to 0 and not nullable
- **Column Rename**: Renamed `culture_per_turn` column to `history` in the `cities` table
- **Migration Journal**: Updated `_journal.json` to register the new migration with version `7` and tag `0001_add_history_interest_pml_and_rename_culture_column`

## Test plan
- [ ] Verify the new column `history_interest_pml` exists in the `games` table with correct default and constraints
- [ ] Confirm the `culture_per_turn` column is renamed to `history` in the `cities` table
- [ ] Ensure the migration runs without errors and the journal reflects the new migration entry

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ef389f9a-9b7c-4b35-877e-86e5cf3e3539