### PR TITLE
Rename 'culture' column to 'history' in players table

### DIFF
--- a/apps/server/drizzle/0002_rename_culture_to_history_in_players.sql
+++ b/apps/server/drizzle/0002_rename_culture_to_history_in_players.sql
@@ -1,0 +1,2 @@
+-- Rename culture column to history in players table
+ALTER TABLE "players" RENAME COLUMN "culture" TO "history";

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1757895613000,
       "tag": "0001_add_history_interest_pml_and_rename_culture_column",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1757895614000,
+      "tag": "0002_rename_culture_to_history_in_players",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Renames the `culture` column to `history` in the `players` table to better reflect the data semantics.
- Adds a new migration script to perform the column rename.
- Updates the migration journal to include the new migration entry.

## Changes

### Database Migrations
- Created `0002_rename_culture_to_history_in_players.sql` to rename the column.
- Updated `_journal.json` to add the migration metadata for version 7.

## Test plan
- Verify that the `players` table no longer has the `culture` column.
- Confirm that the `history` column exists and contains the expected data.
- Run existing queries and tests to ensure no breakage due to the column rename.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3f4290dd-676c-412b-be5e-979aff8b52e4