### PR TITLE
Fix food surplus calculation in CityDataService

### DIFF
--- a/apps/server/src/game/services/CityDataService.ts
+++ b/apps/server/src/game/services/CityDataService.ts
@@ -147,8 +147,9 @@ export class CityDataService {
     };
 
     // Calculate surplus (after consumption) - following freeciv pattern
+    // Note: foodPerTurn already has food consumption deducted by CityTileManagementService
     const surplus = {
-      food: foodPerTurn - city.population * 2, // Food consumption = 2 per citizen
+      food: foodPerTurn, // Food surplus already calculated (production - consumption)
       shields: productionPerTurn, // All shields go to production (no consumption)
       trade: tradePerTurn, // Trade is base (before gold/science split)
       gold: goldPerTurn,


### PR DESCRIPTION
## Summary
- Corrects the calculation of food surplus in the CityDataService
- Removes redundant deduction of food consumption since it's already accounted for

## Changes

### CityDataService
- Updated surplus food calculation to use `foodPerTurn` directly without subtracting population consumption
- Added comment clarifying that `foodPerTurn` already has food consumption deducted by CityTileManagementService

## Test plan
- Verify that food surplus values are accurate and consistent with expected game mechanics
- Ensure no regressions in city resource calculations after the fix

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/32b7e27e-e2ac-4230-a913-1a92b56db1e8